### PR TITLE
Use integers instead of strings for channel types

### DIFF
--- a/objects/creator.js
+++ b/objects/creator.js
@@ -181,7 +181,7 @@ class Creator {
                         };
                     });
                     let options = {
-                        type: 'GUILD_CATEGORY',
+                        type: 4,
                         permissionOverwrites: overwrites,
                     };
 
@@ -216,7 +216,7 @@ class Creator {
                     let textChannel = guildData.textChannel[i];
 
                     let options = {
-                        type: 'GUILD_TEXT',
+                        type: 0,
                         nsfw: textChannel.nsfw,
                         topic: textChannel.topic,
                     };
@@ -269,7 +269,7 @@ class Creator {
                     let voiceChannel = guildData.voiceChannel[i];
 
                     let options = {
-                        type: 'GUILD_VOICE',
+                        type: 2,
                         bitrate: validateBitrate(voiceChannel.bitrate, newGuild.premiumTier),
                         userLimit: validateUserLimit(voiceChannel.userLimit),
                     };

--- a/objects/serializer.js
+++ b/objects/serializer.js
@@ -116,7 +116,7 @@ class Serializer {
      * @returns {Object[]} Serialized category channels
      */
     static serializeCategories(guildToCopy) {
-        let categoryCollection = guildToCopy.channels.cache.filter(c => c.type === 'GUILD_CATEGORY');
+        let categoryCollection = guildToCopy.channels.cache.filter(c => c.type === 4);
         categoryCollection = categoryCollection.sort((a, b) => a.position - b.position);
         let categories = categoryCollection.map(category => {
             let permOverwritesCollection = category.permissionOverwrites.cache.filter(pOver => pOver.type === 'role');
@@ -150,7 +150,7 @@ class Serializer {
      * @returns {Object[]} Serialized text channels
      */
     static serializeTextChannels(guildToCopy) {
-        let textChannelCollection = guildToCopy.channels.cache.filter(c => c.type === 'GUILD_TEXT');
+        let textChannelCollection = guildToCopy.channels.cache.filter(c => c.type === 0);
         textChannelCollection = textChannelCollection.sort((a, b) => a.rawPosition - b.rawPosition);
         let textChannel = textChannelCollection.map(tCh => {
             let permOverwritesCollection = tCh.permissionOverwrites.cache.filter(pOver => pOver.type === 'role');
@@ -189,7 +189,7 @@ class Serializer {
      * @returns {Object[]} Serialized voice channels
      */
     static serializeVoiceChannels(guildToCopy) {
-        let voiceChannelCollection = guildToCopy.channels.cache.filter(c => c.type === 'GUILD_VOICE');
+        let voiceChannelCollection = guildToCopy.channels.cache.filter(c => c.type === 2);
         voiceChannelCollection = voiceChannelCollection.sort((a, b) => a.rawPosition - b.rawPosition);
         let voiceChannel = voiceChannelCollection.map(vCh => {
             let permOverwritesCollection = vCh.permissionOverwrites.cache.filter(pOver => pOver.type === 'role');


### PR DESCRIPTION
At some point, discord.js started using the integers instead of strings for the channel types.  When you backed up or cloned a guild, this would result in no categories, text channels, or voice channels being serialized.

This replaces those key strings with the integers, fixing the problem.